### PR TITLE
debugged on opencv support of opencv4, changed constant names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Change Notes:
+
+changed constant names related to opencv. (src/include/video/* and src/video/*).
+
+changed settings in `build_flags.sh` to turn on PortAudio, ffmpeg, and opencv compiling options.
+
+
 <p align="center"><img width="50%" src="doc/sphinx/_static/images/openSMILE-logoSlogan-color.svg" /></p>
 
 [![Latest release](https://img.shields.io/github/v/release/audeering/opensmile)](https://github.com/audeering/opensmile/releases/latest)

--- a/build_flags.sh
+++ b/build_flags.sh
@@ -32,23 +32,23 @@ cmake_flags=(
     # This ensures that openSMILE runs with optimal performance on the machine it was
     # compiled on but it may not run at all on other machines.
     # Disable if the compiled binary needs to be portable.
-    -DMARCH_NATIVE=OFF
+    -DMARCH_NATIVE=ON
 
     # whether to compile with PortAudio support
-    -DWITH_PORTAUDIO=OFF
+    -DWITH_PORTAUDIO=ON
 
     # whether to compile with FFmpeg support
     # 1. download ffmpeg source distribution
     # 2. run: mkdir build ; cd build
     #         ../configure --enable-shared --disable-static
     #         make ; sudo make install
-    -DWITH_FFMPEG=OFF
+    -DWITH_FFMPEG=ON
 
     # whether to compile with OpenCV support
-    -DWITH_OPENCV=OFF
+    -DWITH_OPENCV=ON
 
     # whether to compile with OpenSL ES support (only applies when building for Android)
-    -DWITH_OPENSLES=ON
+    -DWITH_OPENSLES=OFF
 )
 
 build_flags="${build_flags[@]}"

--- a/src/include/video/openCV_HSVHistogram.hpp
+++ b/src/include/video/openCV_HSVHistogram.hpp
@@ -68,7 +68,7 @@ inline cv::Mat computeSingleHistogram(cv::Mat& input, int& histSize, const float
 inline std::vector<cv::Mat> computeHSVHistogram(cv::Mat& image, int cfgHueSize, int cfgSatSize, int cfgValSize, int normalize)
 {
 	cv::Mat hsvImage;
-	cv::cvtColor(image, hsvImage, CV_BGR2HSV);
+	cv::cvtColor(image, hsvImage, cv::COLOR_BGR2HSV);
 
 	std::vector<cv::Mat> hsvPlanes;
 	cv::split(hsvImage, hsvPlanes);

--- a/src/video/openCVSource.cpp
+++ b/src/video/openCVSource.cpp
@@ -249,9 +249,9 @@ int cOpenCVSource::myFinaliseInstance()
 		bool success = mVideoCapture.open(cfgFilename); // open video stream from file
 
 		// Doesn't work for linux, assume 30 fps...
-		if(mVideoCapture.get(CV_CAP_PROP_FPS) != 0)
+		if(mVideoCapture.get(cv::CAP_PROP_FPS) != 0)
 		{
-			cfgFps = mVideoCapture.get(CV_CAP_PROP_FPS);
+			cfgFps = mVideoCapture.get(cv::CAP_PROP_FPS);
 		}
 	}
 	else
@@ -308,7 +308,7 @@ eTickResult cOpenCVSource::myTick(long long t)
 			mCurrentFrameDisplay_bgr = mCurrentFrame_bgr.clone();
 		}
 
-		cvtColor( mCurrentFrame_bgr, mCurrentFrame_gray, CV_BGR2GRAY );
+		cvtColor( mCurrentFrame_bgr, mCurrentFrame_gray, cv::COLOR_BGR2GRAY );
 		equalizeHist( mCurrentFrame_gray, mCurrentFrame_gray );
 		
 		auto convertColor = std::chrono::high_resolution_clock::now();
@@ -539,7 +539,7 @@ ExtractedFace cOpenCVSource::extractFace(cv::Mat& frame, cv::Mat& frame_gray)
 			     Mat faceROI = frame_gray(insideFrame).clone();
 			     Mat faceResized_gray = Mat::zeros(faceROI.rows, faceROI.cols, faceROI.type());
 			     std::vector<Rect> eyes;
-			     mEyes_cascade.detectMultiScale( faceROI, eyes, 1.1, 2, 0 |CV_HAAR_SCALE_IMAGE, Size(30, 30) );
+			     mEyes_cascade.detectMultiScale( faceROI, eyes, 1.1, 2, 0 |cv::CASCADE_SCALE_IMAGE, Size(30, 30) );
 			     if( eyes.size() == 2)
 			     {
 			    	extractedFace.eyesFound = true;


### PR DESCRIPTION
debugged on opencv support of opencv4, changed constant names.
fix the compiling error of ‘CV_BGR2HSV’ was not declared in this scope and similar errors.