### PR TITLE
DOC: extract opensmile version from conanfile

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,3 +1,4 @@
+import conanfile
 
 
 # Project -----------------------------------------------------------------
@@ -5,9 +6,8 @@
 project = 'openSMILE'
 copyright = '2013-2023 audEERING GmbH and 2008-2013 TU München, MMK'
 author = 'Florian Eyben, Felix Weninger, Martin Wöllmer, Björn Schuller'
-# TODO: add script to get version automatically
-version = '3.0'
-release = '3.0'
+version = conanfile.OpensmileConan.version
+release = conanfile.OpensmileConan.version
 title = '{} Documentation'.format(project)
 
 

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,3 +1,4 @@
+conan
 sphinx
 sphinx-audeering-theme >=1.2.1
 sphinxcontrib-bibtex

--- a/doc/sphinx/requirements.txt.lock
+++ b/doc/sphinx/requirements.txt.lock
@@ -15,24 +15,36 @@ certifi==2023.7.22
     # via requests
 charset-normalizer==3.3.0
     # via requests
+colorama==0.4.6
+    # via conan
+conan==2.0.13
+    # via -r requirements.txt
+distro==1.8.0
+    # via conan
 docutils==0.16
     # via
     #   pybtex-docutils
     #   sphinx
     #   sphinx-audeering-theme
     #   sphinxcontrib-bibtex
+fasteners==0.19
+    # via conan
 idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
-    # via sphinx
+    # via
+    #   conan
+    #   sphinx
 latexcodec==2.0.1
     # via pybtex
 markupsafe==2.1.3
     # via jinja2
 packaging==23.2
     # via sphinx
+patch-ng==1.17.4
+    # via conan
 pybtex==0.24.0
     # via
     #   pybtex-docutils
@@ -41,14 +53,21 @@ pybtex-docutils==1.0.3
     # via sphinxcontrib-bibtex
 pygments==2.16.1
     # via sphinx
+python-dateutil==2.8.2
+    # via conan
 pyyaml==6.0.1
-    # via pybtex
+    # via
+    #   conan
+    #   pybtex
 requests==2.31.0
-    # via sphinx
+    # via
+    #   conan
+    #   sphinx
 six==1.16.0
     # via
     #   latexcodec
     #   pybtex
+    #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==5.3.0
@@ -77,5 +96,7 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-urllib3==2.0.6
-    # via requests
+urllib3==1.26.17
+    # via
+    #   conan
+    #   requests


### PR DESCRIPTION
Use `conanfile.py` as single source of truth for the opensmile version and extract the version from there in `doc/sphinx/conf.py`.