### PR TITLE
Fix creation of ZIP file in make_release.sh

### DIFF
--- a/make_release.sh
+++ b/make_release.sh
@@ -123,6 +123,6 @@ for architecture in "linux-armv7" "linux-armv8" "linux-x86_64" "macos-armv8" "ma
     cp "README.md" "$release/README.md"
 
     # Create ZIP archive
-    zip "$release.zip" "$release"
+    zip -r "$release.zip" "$release"
 
 done


### PR DESCRIPTION
The script was creating empty ZIP files as the `-r` option was missing.

The fixed script was already applied to create the ZIP files for `opensmile` v3.0.2.